### PR TITLE
remove side scroll, body is already full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,5 @@
 /* Heavily stolen from http://pixyll.com/ */
 
-body {
-	width: 100%;
-}
-
 .measure { margin: 0 auto; max-width: 42rem; }
 
 body { color: #333; background-color: white; }


### PR DESCRIPTION
I can't think of the CSS rule that makes this work right now, but basically by setting the width the `<body>` element is pushed out a bit.

![screen shot 2018-06-30 at 11 37 13 am](https://user-images.githubusercontent.com/91254/42127259-77a866b8-7c5a-11e8-9089-8f521d5301ad.png)

![screen shot 2018-06-30 at 11 36 18 am](https://user-images.githubusercontent.com/91254/42127261-7f130520-7c5a-11e8-8ba4-ac520834a833.png)

With the width rule removed, it doesn't side scroll anymore.

* Firefox 61.0
* macOS High Sierra 10.13.5